### PR TITLE
Add `verify-account` screen

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,6 @@
     "orientation": "portrait",
     "icon": "./src/assets/images/app_icon.png",
     "scheme": "myapp",
-    // "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
       "image": "./src/assets/images/splash.png",
@@ -35,6 +34,12 @@
         {
           "cameraPermission": "$(PRODUCT_NAME) needs to access your camera to scan QR codes",
           "recordAudioAndroid": false
+        }
+      ],
+      [
+        "expo-dev-client",
+        {
+          "launchMode": "most-recent"
         }
       ],
       "expo-font",

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,12 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
-  };
-};
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ["babel-preset-expo"],
     plugins: [
       [
         "module-resolver",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,8 @@
         "react-native-text-link": "1.0.1",
         "react-native-web": "~0.19.10",
         "zod": "3.24.2",
-        "zustand": "5.0.3"
+        "zustand": "5.0.3",
+        "zustand-expo-devtools": "0.1.7"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -7511,9 +7512,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -22880,6 +22882,15 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zustand-expo-devtools": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/zustand-expo-devtools/-/zustand-expo-devtools-0.1.7.tgz",
+      "integrity": "sha512-SQMCx6YFbYsIEeZDKxfkoW+UNVi4dweUbQm7x1oi8o5rtiHBcUEduaB6j4AgsvIZ8mIlFI8Z5hgJz1hPXBExPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "react-native-text-link": "1.0.1",
     "react-native-web": "~0.19.10",
     "zod": "3.24.2",
-    "zustand": "5.0.3"
+    "zustand": "5.0.3",
+    "zustand-expo-devtools": "0.1.7"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/app/(tabs)/notifications.tsx
+++ b/src/app/(tabs)/notifications.tsx
@@ -2,12 +2,14 @@ import { Stack, useRouter } from "expo-router";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 
 import Button from "@/components//button";
+import DisplayJSON from "@/components/display-json";
 import NotificationItem from "@/components/notification-item";
-import { useDevStore } from "@/store";
+import { useDevStore, useTestStore } from "@/store";
 import { spectrum } from "@/theme";
 
 export default function NotificationsTab() {
   const enableDevToolbox = useDevStore((s) => s.enableDevToolbox);
+  const { count, message, setCount, setMessage, reset } = useTestStore();
   const router = useRouter();
   return (
     <View style={styles.container}>
@@ -60,6 +62,25 @@ export default function NotificationsTab() {
             <Button
               label="Sign In Screen"
               onPress={() => router.push("/entry/sign-in")}
+              size="md"
+              variant="black"
+            />
+            <DisplayJSON json={{ count, message }} />
+            <Button
+              label="Reset"
+              onPress={() => reset()}
+              size="md"
+              variant="black"
+            />
+            <Button
+              label="Set Count"
+              onPress={() => setCount(10)}
+              size="md"
+              variant="black"
+            />
+            <Button
+              label="Set Message"
+              onPress={() => setMessage("Hello from testing store 3")}
               size="md"
               variant="black"
             />

--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -1,14 +1,112 @@
-import { Stack } from "expo-router";
-import { View, Text, StyleSheet } from "react-native";
+import { router, Stack } from "expo-router";
+import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
 
+import Icon, { IconName } from "@/components/icon";
+import { useAuthStore, useUserStore } from "@/store";
 import { spectrum } from "@/theme";
 
+type SettingItemProps = {
+  icon?: IconName;
+  iconColor?: string;
+  label: string;
+  onPress: () => void;
+  textColor?: string;
+  isLast?: boolean;
+};
+
+const SettingItem = ({
+  icon,
+  iconColor,
+  label,
+  onPress,
+  textColor,
+  isLast,
+}: SettingItemProps) => (
+  <Pressable
+    onPress={onPress}
+    style={({ pressed }) => [
+      styles.settingItem,
+      !isLast && styles.settingItemBorder,
+      pressed && styles.settingItemPressed,
+    ]}
+  >
+    <View style={styles.settingContent}>
+      {icon ? (
+        <Icon
+          name={icon}
+          size={20}
+          color={iconColor || textColor || spectrum.base1Content}
+        />
+      ) : (
+        <View style={{ width: 20 }} />
+      )}
+      <Text style={[styles.settingLabel, textColor && { color: textColor }]}>
+        {label}
+      </Text>
+    </View>
+    <Icon name="chevron-right" size={16} color={spectrum.base1Content} />
+  </Pressable>
+);
+
 export default function SettingsTab() {
+  const clearCognitoUser = useAuthStore((s) => s.clearCognitoUser);
+  const clearUser = useUserStore((s) => s.clearUser);
+
+  const handleLogout = () =>
+    Alert.alert("Logout", "Are you sure you want to sign out?", [
+      {
+        text: "Cancel",
+        style: "cancel",
+      },
+      {
+        text: "Logout",
+        style: "destructive",
+        onPress: () => {
+          clearCognitoUser();
+          clearUser();
+          if (router.canDismiss()) {
+            router.dismissAll();
+          }
+          router.replace("/welcome");
+        },
+      },
+    ]);
+
   return (
     <View style={styles.container}>
-      <Stack.Screen options={{ headerShown: false }} />
-      <Text>Settings will go here</Text>
-      <Text style={styles.pageInfo}>src/app/(tabs)/settings.tsx</Text>
+      <Stack.Screen options={{ title: "Settings" }} />
+      <View style={styles.section}>
+        <SettingItem
+          icon="circle-user-round"
+          iconColor={spectrum.primary}
+          label="Edit Profile"
+          onPress={() => console.log("Edit Profile")}
+        />
+        <SettingItem
+          icon="notifications"
+          iconColor={spectrum.primary}
+          label="Notifications"
+          onPress={() => console.log("Notifications")}
+        />
+        <SettingItem
+          icon="users-round"
+          iconColor={spectrum.primary}
+          label="Invite Friends"
+          onPress={() => console.log("Invite")}
+        />
+        <SettingItem
+          icon="circle-help"
+          iconColor={spectrum.primary}
+          label="Help"
+          onPress={() => console.log("Help")}
+        />
+        <SettingItem
+          label="Logout"
+          onPress={handleLogout}
+          textColor={spectrum.error}
+          isLast
+        />
+      </View>
     </View>
   );
 }
@@ -16,17 +114,36 @@ export default function SettingsTab() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
+    backgroundColor: spectrum.base1[100],
   },
-  pageInfo: {
-    borderTopColor: spectrum.base3Content,
-    borderTopWidth: 1,
-    color: spectrum.base1Content,
-    fontSize: 11,
-    fontWeight: 300,
-    marginVertical: 12,
-    paddingVertical: 12,
-    textAlign: "center",
+  section: {
+    backgroundColor: "white",
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: spectrum.base1,
+  },
+  settingItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    backgroundColor: "white",
+  },
+  settingItemBorder: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: spectrum.base3Content,
+  },
+  settingItemPressed: {
+    backgroundColor: spectrum.base1,
+  },
+  settingContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  settingLabel: {
+    fontSize: 16,
+    color: spectrum.black,
   },
 });

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -17,6 +17,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import CustomHeader from "@/components/header";
 import EntryHeader from "@/components/header-entry";
+import { SessionProvider } from "@/context/auth";
 
 import type { AppStateStatus } from "react-native";
 
@@ -64,7 +65,7 @@ export default function RootLayout() {
       try {
         // Artificially delay to simulate slow loading.
         // TODO: Remove this!
-        // await new Promise((resolve) => setTimeout(resolve, 1500));
+        await new Promise((resolve) => setTimeout(resolve, 1500));
       } catch (e) {
         console.warn(e);
       } finally {
@@ -88,22 +89,24 @@ export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <QueryClientProvider client={queryClient}>
-        <StatusBar style="light" />
-        <Stack>
-          <Stack.Screen
-            name="(tabs)"
-            options={{
-              header: () => <CustomHeader />,
-            }}
-          />
-          <Stack.Screen
-            name="entry"
-            options={{
-              header: () => <EntryHeader />,
-            }}
-          />
-          <Stack.Screen name="welcome" />
-        </Stack>
+        <SessionProvider>
+          <StatusBar style="light" />
+          <Stack>
+            <Stack.Screen
+              name="(tabs)"
+              options={{
+                header: () => <CustomHeader />,
+              }}
+            />
+            <Stack.Screen
+              name="entry"
+              options={{
+                header: () => <EntryHeader />,
+              }}
+            />
+            <Stack.Screen name="welcome" />
+          </Stack>
+        </SessionProvider>
       </QueryClientProvider>
     </SafeAreaProvider>
   );

--- a/src/app/entry/sign-in.tsx
+++ b/src/app/entry/sign-in.tsx
@@ -20,6 +20,7 @@ import LogoDark from "@/assets/svg/logo-dark";
 import Button from "@/components/button";
 import DisplayJSON from "@/components/display-json";
 import ErrorMessage from "@/components/error-message";
+import FormErrorsMessage from "@/components/form-errors-message";
 import Input from "@/components/input";
 import { useAuthStore, useDevStore } from "@/store";
 import { spectrum } from "@/theme";
@@ -28,6 +29,8 @@ import { zPassword } from "@/utils/password";
 
 import type { CognitoUser } from "@/types/auth";
 import type { FieldError } from "react-hook-form";
+
+const inputWidth = 284;
 
 type CognitoAuthResponse = {
   token: string;
@@ -140,7 +143,7 @@ export default function SignInScreen() {
       <View style={styles.container}>
         <LogoDark />
         <ErrorMessage error={error} />
-        <View>
+        <View style={styles.inputContainer}>
           <Controller
             control={control}
             name="account"
@@ -149,7 +152,6 @@ export default function SignInScreen() {
                 autoCapitalize="none"
                 autoComplete="email"
                 autoCorrect={false}
-                clearButtonMode="always"
                 keyboardType="email-address"
                 onBlur={onBlur}
                 onChangeText={onChange}
@@ -163,9 +165,9 @@ export default function SignInScreen() {
               />
             )}
           />
-          <ErrorMessage error={errors.account} style={{ paddingTop: 4 }} />
+          <FormErrorsMessage errors={errors} name="account" />
         </View>
-        <View>
+        <View style={styles.inputContainer}>
           <Controller
             control={control}
             name="password"
@@ -174,7 +176,6 @@ export default function SignInScreen() {
                 autoCapitalize="none"
                 autoComplete="password"
                 autoCorrect={false}
-                clearButtonMode="always"
                 onBlur={onBlur}
                 onChangeText={onChange}
                 onSubmitEditing={onSubmit}
@@ -188,7 +189,7 @@ export default function SignInScreen() {
               />
             )}
           />
-          <ErrorMessage error={errors.password} style={{ paddingTop: 4 }} />
+          <FormErrorsMessage errors={errors} name="password" />
         </View>
       </View>
       <View style={{ alignItems: "center", gap: 16, paddingTop: 20 }}>
@@ -198,10 +199,9 @@ export default function SignInScreen() {
           label={loading ? "Signing In ..." : "Sign In"}
           size="lg"
           buttonStyle={{
-            width: 284,
+            width: inputWidth,
           }}
         />
-
         <View style={{ alignItems: "center" }}>
           <Text style={styles.textHelpful}>Forgot password?</Text>
           <TextLink
@@ -290,8 +290,13 @@ const styles = StyleSheet.create({
     gap: 16,
     paddingTop: 32,
   },
+  inputContainer: {
+    gap: 8,
+    width: inputWidth,
+  },
   textInput: {
-    width: 284,
+    // backgroundColor: "orange",
+    width: inputWidth,
   },
   textHelpful: {
     color: spectrum.base2Content,

--- a/src/app/entry/sign-up/_layout.tsx
+++ b/src/app/entry/sign-up/_layout.tsx
@@ -1,68 +1,68 @@
-import { zodResolver } from "@hookform/resolvers/zod";
+// import { zodResolver } from "@hookform/resolvers/zod";
 import { Slot, Stack } from "expo-router";
-import { useForm, FormProvider } from "react-hook-form";
-import { ScrollView, View } from "react-native";
-import { z } from "zod";
+// import { useForm, FormProvider } from "react-hook-form";
+import { ScrollView } from "react-native";
+// import { z } from "zod";
 
-import { isValidEmail } from "@/utils/email";
-import { zPassword } from "@/utils/password";
+// import { isValidEmail } from "@/utils/email";
+// import { zPassword } from "@/utils/password";
 
-const schema = z
-  .object({
-    account: z.string().refine((val) => isValidEmail(val), {
-      message: "Please enter a valid email",
-    }),
-    password: zPassword,
-    password2: z.string(),
-    confirmCode: z.string().refine((val) => val.length === 6, {
-      message: "Confirmation code must be 6 digits",
-    }),
-    firstName: z.string(),
-    lastName: z.string(),
-    username: z.string(),
-    phone: z.string(),
-    email: z.string(),
-    signUpCode: z.string(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.password !== data.password2) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["password2"],
-        message: `Passwords don’t match`,
-      });
-    }
-  });
+// const schema = z
+//   .object({
+//     account: z.string().refine((val) => isValidEmail(val), {
+//       message: "Please enter a valid email",
+//     }),
+//     password: zPassword,
+//     password2: z.string(),
+//     confirmCode: z.string().refine((val) => val.length === 6, {
+//       message: "Confirmation code must be 6 digits",
+//     }),
+//     firstName: z.string(),
+//     lastName: z.string(),
+//     username: z.string(),
+//     phone: z.string(),
+//     email: z.string(),
+//     signUpCode: z.string(),
+//   })
+//   .superRefine((data, ctx) => {
+//     if (data.password !== data.password2) {
+//       ctx.addIssue({
+//         code: z.ZodIssueCode.custom,
+//         path: ["password2"],
+//         message: `Passwords don’t match`,
+//       });
+//     }
+//   });
 
-type FormValues = z.infer<typeof schema>;
+// type FormValues = z.infer<typeof schema>;
 
 export default function SignUpLayout() {
-  const methods = useForm<FormValues>({
-    defaultValues: {
-      // part 1
-      account: "",
-      password: "",
-      password2: "",
-      // part 2
-      confirmCode: "",
-      // part 3
-      firstName: "",
-      lastName: "",
-      username: "",
-      phone: "",
-      email: "",
-      // part 4
-      signUpCode: "",
-    },
-    resolver: zodResolver(schema),
-  });
+  // const methods = useForm<FormValues>({
+  //   defaultValues: {
+  //     // part 1
+  //     account: "",
+  //     password: "",
+  //     password2: "",
+  //     // part 2
+  //     confirmCode: "",
+  //     // part 3
+  //     firstName: "",
+  //     lastName: "",
+  //     username: "",
+  //     phone: "",
+  //     email: "",
+  //     // part 4
+  //     signUpCode: "",
+  //   },
+  //   resolver: zodResolver(schema),
+  // });
 
   return (
     <ScrollView style={{ flex: 1 }}>
       <Stack.Screen options={{ headerShown: false }} />
-      <FormProvider {...methods}>
-        <Slot />
-      </FormProvider>
+      {/* <FormProvider {...methods}> */}
+      <Slot />
+      {/* </FormProvider> */}
     </ScrollView>
   );
 }

--- a/src/app/entry/sign-up/_layout.tsx
+++ b/src/app/entry/sign-up/_layout.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Slot, Stack } from "expo-router";
 import { useForm, FormProvider } from "react-hook-form";
-import { ScrollView } from "react-native";
+import { ScrollView, View } from "react-native";
 import { z } from "zod";
 
 import { isValidEmail } from "@/utils/email";
@@ -14,7 +14,9 @@ const schema = z
     }),
     password: zPassword,
     password2: z.string(),
-    confirmCode: z.string(),
+    confirmCode: z.string().refine((val) => val.length === 6, {
+      message: "Confirmation code must be 6 digits",
+    }),
     firstName: z.string(),
     lastName: z.string(),
     username: z.string(),

--- a/src/app/entry/sign-up/collect-account.tsx
+++ b/src/app/entry/sign-up/collect-account.tsx
@@ -72,130 +72,133 @@ function SignUpWithEmailScreen() {
   return (
     <>
       <View style={styles.container}>
-        <View style={{ gap: 20 }}>
-          <Text style={styles.pageTitleText}>Sign up with email</Text>
-          <ErrorMessage error={signUpError} style={styles.inputContainer} />
-          <View style={styles.inputContainer}>
-            <Controller
-              control={control}
-              name="account"
-              render={({ field: { onChange, onBlur, value } }) => (
-                <Input
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  keyboardType="email-address"
-                  onBlur={onBlur}
-                  onChangeText={onChange}
-                  onSubmitEditing={() => passwordInputRef.current?.focus()}
-                  placeholder={"Email Address"}
-                  ref={accountInputRef}
-                  returnKeyType="next"
-                  style={styles.textInput}
-                  textContentType="username"
-                  value={value}
-                />
-              )}
-            />
-            <FormErrorsMessage errors={errors} name="account" />
-          </View>
-          <View style={styles.inputContainer}>
-            <Controller
-              control={control}
-              name="password"
-              render={({ field: { onChange, onBlur, value } }) => (
-                <Input
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  onBlur={onBlur}
-                  onChangeText={onChange}
-                  onSubmitEditing={() => password2InputRef.current?.focus()}
-                  placeholder="Password"
-                  ref={passwordInputRef}
-                  returnKeyType="next"
-                  secureTextEntry
-                  style={styles.textInput}
-                  textContentType="password"
-                  value={value}
-                />
-              )}
-            />
-            <FormErrorsMessage errors={errors} name="password" />
-          </View>
-          <View style={styles.inputContainer}>
-            <Controller
-              control={control}
-              name="password2"
-              render={({ field: { onChange, onBlur, value } }) => (
-                <Input
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  onBlur={onBlur}
-                  onChangeText={onChange}
-                  placeholder="Confirm Password"
-                  ref={password2InputRef}
-                  returnKeyType="done"
-                  secureTextEntry
-                  style={styles.textInput}
-                  textContentType="password"
-                  value={value}
-                />
-              )}
-            />
-            <FormErrorsMessage errors={errors} name="password2" />
-          </View>
-          <View style={{ paddingTop: 12 }}>
-            <Button
-              buttonStyle={{ width: inputWidth }}
-              disabled={signUpLoading}
-              label="Next"
-              onPress={onSubmit}
-              size="lg"
-              variant="primary"
-            />
-          </View>
-          <View style={{ alignItems: "center" }}>
-            <Text style={styles.textHelpful}>Already a user?</Text>
-            <TextLink
-              links={[
-                {
-                  text: "Sign in",
-                  onPress: () => router.push("/entry/sign-in"),
-                },
-              ]}
-              textStyle={styles.textHelpful}
-              textLinkStyle={{
-                color: spectrum.primary,
-                textDecorationLine: "underline",
-              }}
-            >
-              Sign in.
-            </TextLink>
-          </View>
+        <Text style={styles.pageTitleText}>Sign up with email</Text>
+        <ErrorMessage error={signUpError} style={styles.inputContainer} />
+        <View style={styles.inputContainer}>
+          <Controller
+            control={control}
+            name="account"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Input
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="email-address"
+                onBlur={onBlur}
+                onChangeText={onChange}
+                onSubmitEditing={() => passwordInputRef.current?.focus()}
+                placeholder={"Email Address"}
+                ref={accountInputRef}
+                returnKeyType="next"
+                style={styles.textInput}
+                textContentType="username"
+                value={value}
+              />
+            )}
+          />
+          <FormErrorsMessage errors={errors} name="account" />
         </View>
-        {accountValue && isValidEmail(accountValue) && !errors.account && (
-          <View style={{ alignItems: "center", paddingTop: 16 }}>
-            <Text style={styles.textHelpful}>Have a code?</Text>
-            <TextLink
-              links={[
-                {
-                  text: "Confirm",
-                  onPress: handleRedirectConfirm,
-                },
-              ]}
-              textStyle={styles.textHelpful}
-              textLinkStyle={{
-                color: spectrum.primary,
-                textDecorationLine: "underline",
-              }}
-            >
-              Confirm your account.
-            </TextLink>
-          </View>
-        )}
+        <View style={styles.inputContainer}>
+          <Controller
+            control={control}
+            name="password"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Input
+                autoCapitalize="none"
+                autoCorrect={false}
+                onBlur={onBlur}
+                onChangeText={onChange}
+                onSubmitEditing={() => password2InputRef.current?.focus()}
+                placeholder="Password"
+                ref={passwordInputRef}
+                returnKeyType="next"
+                secureTextEntry
+                style={styles.textInput}
+                textContentType="password"
+                value={value}
+              />
+            )}
+          />
+          <FormErrorsMessage errors={errors} name="password" />
+        </View>
+        <View style={styles.inputContainer}>
+          <Controller
+            control={control}
+            name="password2"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Input
+                autoCapitalize="none"
+                autoCorrect={false}
+                onBlur={onBlur}
+                onChangeText={onChange}
+                placeholder="Confirm Password"
+                ref={password2InputRef}
+                returnKeyType="done"
+                secureTextEntry
+                style={styles.textInput}
+                textContentType="password"
+                value={value}
+              />
+            )}
+          />
+          <FormErrorsMessage errors={errors} name="password2" />
+        </View>
+        <Button
+          buttonStyle={{ width: inputWidth }}
+          disabled={signUpLoading}
+          label="Next"
+          onPress={onSubmit}
+          size="lg"
+          variant="primary"
+        />
+        <View style={{ alignItems: "center" }}>
+          <Text style={styles.textHelpful}>Already a user?</Text>
+          <TextLink
+            links={[
+              {
+                text: "Sign in",
+                onPress: () => router.push("/entry/sign-in"),
+              },
+            ]}
+            textStyle={styles.textHelpful}
+            textLinkStyle={{
+              color: spectrum.primary,
+              textDecorationLine: "underline",
+            }}
+          >
+            Sign in.
+          </TextLink>
+        </View>
       </View>
+      {accountValue && isValidEmail(accountValue) && !errors.account && (
+        <View style={{ alignItems: "center", paddingTop: 16 }}>
+          <Text style={styles.textHelpful}>Have a code?</Text>
+          <TextLink
+            links={[
+              {
+                text: "Confirm",
+                onPress: handleRedirectConfirm,
+              },
+            ]}
+            textStyle={styles.textHelpful}
+            textLinkStyle={{
+              color: spectrum.primary,
+              textDecorationLine: "underline",
+            }}
+          >
+            Confirm your account.
+          </TextLink>
+        </View>
+      )}
       {enableDevToolbox && (
         <View style={[styles.toolbox, { marginBottom: insets.bottom }]}>
           <Text style={styles.toolboxHeader}>Dev Toolbox</Text>
+          <Button
+            iconName="arrow-right"
+            label="verify-account.tsx"
+            onPress={() => router.push("/entry/sign-up/verify-account")}
+            size="sm"
+            variant="black"
+          />
           <Button
             buttonStyle={{ width: 200 }}
             iconName="refresh"
@@ -280,6 +283,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: "center",
+    gap: 20,
     justifyContent: "center",
   },
   inputContainer: {

--- a/src/app/entry/sign-up/index.tsx
+++ b/src/app/entry/sign-up/index.tsx
@@ -3,5 +3,6 @@ import React from "react";
 import { Redirect } from "expo-router";
 
 export default function SignUp() {
-  return <Redirect href="/entry/sign-up/collect-account" />;
+  // return <Redirect href="/entry/sign-up/collect-account" />;
+  return <Redirect href="/entry/sign-up/verify-account" />;
 }

--- a/src/app/entry/sign-up/verify-account.tsx
+++ b/src/app/entry/sign-up/verify-account.tsx
@@ -45,7 +45,6 @@ const SignUpVerifyScreen = () => {
   });
 
   const cognitoUser = useAuthStore((s) => s.cognitoUser);
-  console.log("cognitoUser", cognitoUser);
   const accountValue = cognitoUser?.attributes?.email;
 
   const router = useRouter();

--- a/src/app/entry/sign-up/verify-account.tsx
+++ b/src/app/entry/sign-up/verify-account.tsx
@@ -1,19 +1,201 @@
-import { View, Text, StyleSheet } from "react-native";
+import { useEffect, useState } from "react";
 
-const MyComponent = () => {
+import { Auth } from "aws-amplify";
+import { useRouter } from "expo-router";
+import { Controller, useFormContext } from "react-hook-form";
+import { View, Text, StyleSheet } from "react-native";
+import TextLink from "react-native-text-link";
+
+import Button from "@/components/button";
+import ErrorMessage from "@/components/error-message";
+import FormErrorsMessage from "@/components/form-errors-message";
+import Input from "@/components/input";
+import { useDevStore } from "@/store";
+import { spectrum } from "@/theme";
+
+const inputWidth = 244;
+
+const SignUpVerifyScreen = () => {
+  const enableDevToolbox = useDevStore((s) => s.enableDevToolbox);
+  const {
+    clearErrors,
+    control,
+    formState: { errors },
+    handleSubmit,
+    setError: setErrorForm,
+    watch,
+  } = useFormContext();
+  const accountValue = watch("account");
+
+  const router = useRouter();
+
+  const [loading, setLoading] = useState(false);
+  const [valid, setValid] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const onSubmit = handleSubmit(async (data) => {
+    if (valid) return true;
+    setLoading(true);
+    setError(null);
+    const { account, confirmCode } = data;
+
+    try {
+      await Auth.confirmSignUp(account, confirmCode);
+    } catch (error) {
+      setError(error as Error);
+      setLoading(false);
+      return false;
+    }
+
+    setValid(true);
+    setLoading(false);
+    return true;
+  });
+
   return (
-    <View style={styles.container}>
-      <Text>verify account</Text>
-    </View>
+    <>
+      <View style={styles.container}>
+        <Text style={styles.pageTitleText}>Verify your account</Text>
+        <Text
+          style={styles.explanationText}
+          numberOfLines={2}
+          adjustsFontSizeToFit
+        >
+          You will receive a code to your email at {accountValue}
+        </Text>
+        <View style={styles.inputContainer}>
+          <Controller
+            control={control}
+            name="confirmCode"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <Input
+                disabled={valid}
+                keyboardType="numeric"
+                onBlur={onBlur}
+                onChangeText={onChange}
+                placeholder="Confirmation Code"
+                style={styles.textInput}
+                textContentType="oneTimeCode"
+                value={value}
+              />
+            )}
+          />
+          <FormErrorsMessage errors={errors} name="confirmCode" />
+          <ErrorMessage error={error} style={styles.inputContainer} />
+        </View>
+        <Button
+          buttonStyle={{ width: inputWidth }}
+          disabled={loading}
+          label="Next"
+          onPress={onSubmit}
+          size="lg"
+          variant="primary"
+        />
+
+        <View style={{ alignItems: "center" }}>
+          <Text style={styles.textHelpful}>Didn’t get it?</Text>
+          <TextLink
+            links={[
+              {
+                text: "Resend",
+                onPress: () => console.log("resend"),
+              },
+            ]}
+            textStyle={styles.textHelpful}
+            textLinkStyle={{
+              color: spectrum.primary,
+              textDecorationLine: "underline",
+            }}
+          >
+            Resend.
+          </TextLink>
+        </View>
+      </View>
+      {enableDevToolbox && (
+        <View
+          style={{
+            alignItems: "center",
+            borderColor: spectrum.black,
+            borderWidth: StyleSheet.hairlineWidth,
+            gap: 2,
+            justifyContent: "center",
+            margin: 16,
+            paddingHorizontal: 8,
+            paddingTop: 2,
+            paddingBottom: 8,
+          }}
+        >
+          <Text
+            style={{
+              color: spectrum.black,
+              fontSize: 12,
+              fontWeight: 400,
+              lineHeight: 21,
+              paddingBottom: 8,
+              textAlign: "center",
+            }}
+          >
+            Dev Toolbox
+          </Text>
+          <Button
+            iconName="arrow-right"
+            label="collect-account.tsx"
+            onPress={() => router.push("/entry/sign-up/collect-account")}
+            size="sm"
+            variant="black"
+          />
+          <Button
+            iconName="refresh"
+            label="Toggle Error State (confirmCode)"
+            onPress={() => {
+              if (!errors.confirmCode) {
+                setErrorForm("confirmCode", {
+                  type: "custom",
+                  message: "Confirm code error message goes here.",
+                });
+              } else {
+                clearErrors("confirmCode");
+              }
+            }}
+            size="sm"
+            variant="black"
+          />
+        </View>
+      )}
+    </>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
     alignItems: "center",
+    gap: 20,
+  },
+  inputContainer: {
+    gap: 8,
+    width: inputWidth,
+  },
+  pageTitleText: {
+    fontSize: 24,
+    fontWeight: 700,
+    marginTop: 32,
+    textAlign: "center",
+  },
+  explanationText: {
+    fontSize: 16,
+    marginTop: -8, // this visual spacing feels better
+    paddingHorizontal: 32,
+    textAlign: "center",
+  },
+  textInput: {
+    width: inputWidth,
+  },
+  textHelpful: {
+    color: spectrum.base2Content,
+    fontSize: 16,
+    fontWeight: 500,
   },
 });
 
-export default MyComponent;
+export default SignUpVerifyScreen;

--- a/src/app/welcome.tsx
+++ b/src/app/welcome.tsx
@@ -183,7 +183,7 @@ const styles = StyleSheet.create({
     textDecorationLine: "underline",
   },
   version: {
-    color: spectrum.base2Content,
+    color: spectrum.base1Content,
     fontSize: 12,
     fontWeight: 200,
     lineHeight: 18,

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -1,5 +1,13 @@
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import { CircleDollarSign, Image } from "lucide-react-native";
+import {
+  Bell,
+  ChevronRight,
+  CircleDollarSign,
+  CircleHelp,
+  CircleUserRound,
+  Image,
+  UsersRound,
+} from "lucide-react-native";
 
 import CampaignCheckIn from "@/assets/svg/campaign-check-in";
 import CampaignCheckInQRCode from "@/assets/svg/campaign-check-in-qr-code";
@@ -30,9 +38,14 @@ const localIcons = {
 };
 
 const lucideIcons = {
+  bell: Bell,
+  "chevron-right": ChevronRight,
   "circle-dollar-sign": CircleDollarSign,
-  CircleDollarSign: CircleDollarSign,
+  "circle-help": CircleHelp,
+  "circle-user-round": CircleUserRound,
   image: Image,
+  notifications: Bell,
+  "users-round": UsersRound,
 };
 
 export type IconName =

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -5,6 +5,7 @@ import {
   CircleDollarSign,
   CircleHelp,
   CircleUserRound,
+  CircleX,
   Image,
   UsersRound,
 } from "lucide-react-native";
@@ -43,6 +44,7 @@ const lucideIcons = {
   "circle-dollar-sign": CircleDollarSign,
   "circle-help": CircleHelp,
   "circle-user-round": CircleUserRound,
+  "circle-x": CircleX,
   image: Image,
   notifications: Bell,
   "users-round": UsersRound,

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,0 +1,76 @@
+import {
+  useContext,
+  useEffect,
+  createContext,
+  type PropsWithChildren,
+} from "react";
+
+import { usePathname, useRouter } from "expo-router";
+
+import { useAuthStore } from "@/store";
+
+import type { CognitoUser } from "@/types/auth";
+
+interface AuthContextType {
+  cognitoUser: CognitoUser | null;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+// This hook can be used to access the user info.
+export function useSession() {
+  const value = useContext(AuthContext);
+  if (value === null) {
+    throw new Error("useSession must be wrapped in a <SessionProvider />");
+  }
+
+  return value;
+}
+
+// List of route prefixes that will not be protected
+const unprotectedPrefixes = ["/welcome", "/entry"];
+
+// This hook runs on every route change and will protect the route access based on user authentication.
+function useProtectedRoute(user: CognitoUser | null) {
+  const pathname = usePathname();
+  console.log("[useProtectedRoute] pathname:", pathname);
+  const router = useRouter();
+
+  useEffect(() => {
+    const isUnprotected = unprotectedPrefixes.some((path) =>
+      pathname.startsWith(path),
+    );
+
+    // If the user is not signed in and the path is protected, redirect to welcome page.
+    if (!user && !isUnprotected) {
+      console.log("[useProtectedRoute] Redirecting to welcome");
+      if (router.canDismiss()) {
+        router.dismissAll();
+      }
+      router.replace("/welcome");
+    }
+    // If the user is signed in and the path is unprotected, we still redirect to dashboard page. TODO: Just show the current page?
+    else if (user && isUnprotected) {
+      console.log("[useProtectedRoute] Redirecting to dashboard");
+      if (router.canDismiss()) {
+        router.dismissAll();
+      }
+      router.replace("/(tabs)");
+    }
+    // Otherwise, do nothing.
+    else {
+      console.log("[useProtectedRoute] Not redirecting");
+    }
+  }, [user, pathname]); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+export function SessionProvider({ children }: PropsWithChildren) {
+  const cognitoUser = useAuthStore((s) => s.cognitoUser);
+  useProtectedRoute(cognitoUser);
+
+  return (
+    <AuthContext.Provider value={{ cognitoUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/store/dev.ts
+++ b/src/store/dev.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { devtools, persist } from "zustand/middleware";
+import { persist } from "zustand/middleware";
+import { middleware } from "zustand-expo-devtools";
 
 interface DevState {
   enableDevToolbox: boolean;
@@ -10,36 +11,30 @@ interface DevActions {
 }
 
 const initialState: DevState = {
-  // enableDevToolbox: false,
-  enableDevToolbox: process.env.NODE_ENV === "development",
+  enableDevToolbox: false,
+  // enableDevToolbox: process.env.NODE_ENV === "development",
 };
 
-const envAwareDevtools = (
-  process.env.NODE_ENV === "production" ? (f) => f : devtools
-) as typeof devtools;
-
 const useDevStore = create<DevState & DevActions>()(
-  envAwareDevtools(
-    persist(
-      (set, get) => ({
-        ...initialState,
-        toggleEnableDevToolbox: () =>
-          set(
-            (state) => ({
-              ...state,
-              enableDevToolbox: !state.enableDevToolbox,
-            }),
-            false,
-            "dev/toggleEnableDevToolbox",
-          ),
-      }),
-      {
-        name: "dev-storage",
-        version: 1,
-      },
-    ),
-    { name: "Dev Store" },
+  persist(
+    (set, get) => ({
+      ...initialState,
+      toggleEnableDevToolbox: () =>
+        set((state) => ({
+          ...state,
+          enableDevToolbox: !state.enableDevToolbox,
+        })),
+    }),
+    {
+      name: "dev-storage",
+      version: 1,
+    },
   ),
 );
+
+middleware(useDevStore, {
+  name: "dev-store",
+  version: 1,
+});
 
 export default useDevStore;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,3 +1,4 @@
 export { default as useAuthStore } from "./auth";
 export { default as useDevStore } from "./dev";
+export { default as useUserStore } from "./user";
 export { default as useTestStore } from "./test";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,2 +1,3 @@
 export { default as useAuthStore } from "./auth";
 export { default as useDevStore } from "./dev";
+export { default as useTestStore } from "./test";

--- a/src/store/test.ts
+++ b/src/store/test.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import { middleware } from "zustand-expo-devtools";
+
+interface TestState {
+  count: number;
+  message: string;
+}
+
+interface TestActions {
+  setCount: (count: number) => void;
+  setMessage: (message: string) => void;
+  reset: () => void;
+}
+
+const initialState: TestState = {
+  count: 0,
+  message: "Hello from testing store",
+};
+
+const useTestStore = create<TestState & TestActions>()((set) => ({
+  ...initialState,
+  setCount: (count) =>
+    set((state) => ({
+      ...state,
+      count,
+    })),
+  setMessage: (message) =>
+    set((state) => ({
+      ...state,
+      message,
+    })),
+  reset: () => set(initialState),
+}));
+
+middleware(useTestStore, {
+  name: "test-store",
+  version: 1,
+});
+
+export default useTestStore;

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,0 +1,107 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
+import { middleware } from "zustand-expo-devtools";
+
+import { expoFileSystemStorage } from "./expoFileSystemStorage";
+
+interface GotMe {
+  uuid: string;
+  date_joined: string;
+  merchants: {
+    uuid: string;
+    name: string;
+  }[];
+  locations: {
+    uuid: string;
+    name: string;
+    nickname: string;
+    verified: string | null;
+    address1: string;
+    city: string;
+    state: string;
+    zip: string;
+  }[];
+  token_balance: number;
+  otc_redeemed: boolean;
+  staff: boolean;
+}
+
+interface UserState {
+  attributes: {
+    sub: string;
+    email: string; // we only use email for now
+    email_verified: boolean;
+  };
+  authToken: string;
+  gotme: GotMe;
+  locationUuid: string;
+  merchantUuid: string;
+}
+
+interface UserActions {
+  clearUser: () => void;
+  setAttributes: (attributes: UserState["attributes"]) => void;
+  setAuthToken: (authToken: string) => void;
+  setGotme: (gotme: GotMe) => void;
+  setLocationUuid: (locationUuid: string) => void;
+  setMerchantUuid: (merchantUuid: string) => void;
+}
+
+const initialState: UserState = {
+  attributes: {
+    sub: "",
+    email: "",
+    email_verified: false,
+  },
+  authToken: "",
+  gotme: {
+    uuid: "",
+    date_joined: "",
+    merchants: [],
+    locations: [],
+    token_balance: 0,
+    otc_redeemed: false,
+    staff: false,
+  },
+  locationUuid: "",
+  merchantUuid: "",
+};
+
+const useUserStore = create<UserState & UserActions>()(
+  persist(
+    immer((set) => ({
+      ...initialState,
+      clearUser: () => set(() => initialState),
+      setAttributes: (attributes) =>
+        set((state) => {
+          state.attributes = attributes;
+        }),
+      setAuthToken: (authToken) =>
+        set((state) => {
+          state.authToken = authToken;
+        }),
+      setGotme: (gotme) =>
+        set((state) => {
+          state.gotme = gotme;
+        }),
+      setLocationUuid: (locationUuid) =>
+        set((state) => {
+          state.locationUuid = locationUuid;
+        }),
+      setMerchantUuid: (merchantUuid) =>
+        set((state) => {
+          state.merchantUuid = merchantUuid;
+        }),
+    })),
+    {
+      name: "user-storage",
+      version: 1,
+      storage: expoFileSystemStorage,
+    },
+  ),
+);
+
+middleware(useUserStore);
+
+export default useUserStore;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,43 @@
+export type CognitoUser = {
+  attributes: {
+    email: string; // our `account` value should be the same as this `email`
+    email_verified: boolean;
+    sub: string; // unique identifier
+  };
+  authenticationFlowType: string;
+  signInUserSession: {
+    accessToken: {
+      jwtToken: string;
+    };
+    idToken: {
+      jwtToken: string;
+    };
+  };
+  userDataKey: string;
+  username: string; // same as email when signing up with email
+};
+
+export type GoogleUser = {
+  email: string;
+  id: string;
+  name: string;
+  token: string;
+};
+
+export function isCognitoUser(
+  user: CognitoUser | GoogleUser,
+): user is CognitoUser {
+  return (user as CognitoUser).username !== undefined;
+}
+
+export function isGoogleUser(
+  user: CognitoUser | GoogleUser,
+): user is GoogleUser {
+  return (user as GoogleUser).id !== undefined;
+}
+
+export function isUser(
+  user: CognitoUser | GoogleUser,
+): user is CognitoUser | GoogleUser {
+  return isCognitoUser(user) || isGoogleUser(user);
+}


### PR DESCRIPTION
Add a screen for the next step in Sign Up, verify-account

Add a SessionProvider to guard routes
Use separate React Hook Form forms per screen, instead of cramming all Sign Up screens into one RHF Context
Add zustand-expo-devtools (default zustand devtools don't work in React Native)
Some fixes