### PR TITLE
Add improved phone parsing

### DIFF
--- a/src/app/(tabs)/wallet.tsx
+++ b/src/app/(tabs)/wallet.tsx
@@ -15,8 +15,8 @@ import Icon from "@/components/icon";
 import { data } from "@/mocks/fixtures";
 import { spectrum } from "@/theme";
 
-import type { IconName } from "@/components/icon";
-import type { HistoryItem } from "@/mocks/fixtures";
+import type { HistoryIconName, IconName } from "@/components/icon";
+import type { HistoryItem } from "@/mocks/fixtures"; // TODO: Move types to a types file, instead of mocks.
 
 const user_tag = "SillyUserTag";
 const balanceStateLoading: boolean = false;
@@ -33,14 +33,22 @@ const generateTypeIconValue = (
   item: HistoryItem,
 ): [string, IconName, number] => {
   if (item.type !== "transfer") {
-    return [item.type, `Campaign${item.type}` as IconName, item.rewardGetToken];
+    // The 5 possible values for item.type are "CheckIn", "CheckInQRCode",
+    // "Referral", "Review", "Survey".
+    const iconName: HistoryIconName = `Campaign${item.type}`;
+    return [item.type, iconName, item.rewardGetToken];
   } else {
     if (item.actionDescription.indexOf("redeem") > -1) {
-      return ["Redeem", "CircleDollarSign", -item.rewardGetToken];
+      return ["Redeem", "circle-dollar-sign", -item.rewardGetToken];
     }
     const capitalizedStr =
       item.type.charAt(0).toUpperCase() + item.type.slice(1);
-    return [capitalizedStr, capitalizedStr as IconName, -item.rewardGetToken]; // TODO: "as IconName" here is a lie. I mean, promise to fix it later.
+    // NB: "as IconName" below is a promise with no guarantee. But it won't
+    // break anything and it's not a big deal and it should only come into play
+    // if the backend changes and we don't update the new values here in the
+    // mobile app.
+    // TODO: Fix this later? Is there a possible fix?
+    return [capitalizedStr, capitalizedStr as IconName, -item.rewardGetToken];
   }
 };
 

--- a/src/app/location/[uuid].tsx
+++ b/src/app/location/[uuid].tsx
@@ -208,7 +208,7 @@ export default function LocationScreen() {
                     onPress={() => callNumber(location.business_phone)}
                   >
                     <Text style={styles.phone}>
-                      {phoneFormatter(location.business_phone)}
+                      {phoneFormatter(location.business_phone || "")}
                     </Text>
                   </TouchableOpacity>
                 </YStack>

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -27,11 +27,6 @@ export type FontAwesomeIconStyle = React.ComponentProps<
 >["style"];
 
 const localIcons = {
-  "campaign-check-in": CampaignCheckIn,
-  "campaign-check-in-qr-code": CampaignCheckInQRCode,
-  "campaign-referral": CampaignReferral,
-  "campaign-review": CampaignReview,
-  "campaign-survey": CampaignSurvey,
   CampaignCheckIn: CampaignCheckIn,
   CampaignCheckInQRCode: CampaignCheckInQRCode,
   CampaignReferral: CampaignReferral,
@@ -53,9 +48,11 @@ const lucideIcons = {
 };
 
 export type IconName =
-  | FontAwesomeIconName
+  | keyof typeof localIcons
   | keyof typeof lucideIcons
-  | keyof typeof localIcons;
+  | FontAwesomeIconName;
+
+export type HistoryIconName = keyof typeof localIcons;
 
 interface IconProps {
   color?: string;

--- a/src/mocks/fixtures/history.ts
+++ b/src/mocks/fixtures/history.ts
@@ -10,7 +10,13 @@ type HistoryItem = {
   recentOperations: any[];
   rewardGetToken: number;
   status: string;
-  type: string;
+  type:
+    | "transfer"
+    | "CheckIn"
+    | "CheckInQRCode"
+    | "Referral"
+    | "Review"
+    | "Survey";
   updateTimestamp: string;
   uuid: string;
   location_name?: string;

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -7,147 +7,21 @@ import { CognitoUser } from "@/types/auth";
 
 import { expoFileSystemStorage } from "./expoFileSystemStorage";
 
-// import { isValidMobilePhone } from "@/utils/phone";
-
 interface AuthState {
   cognitoUser: CognitoUser | null; // holds user data from AWS Cognito
   token: string; // holds token data from AWS Cognito
-  // user: any; // holds the `gotme` data: uuid, date_joined, merchants, locations, token_balance, otc_redeemed, staff
-  // // isTokenLoading: boolean;
-  // // isAuthenticated: boolean;
-  // // user: any; // is set to cognitoUser plus token data
-  // tempUser: any; // is used temporarily for confirm sign up code then set to null
-  // isMobile: boolean;
-  // resendConfirmCodeTimestamp: Date | null;
-  // signInState: {
-  //   loading: boolean;
-  //   error: string | undefined;
-  // };
-  // signUpState: {
-  //   collectAccount: {
-  //     loading: boolean;
-  //     valid: boolean;
-  //     error: string | null;
-  //   };
-  //   verifyAccount: {
-  //     loading: boolean;
-  //     valid: boolean;
-  //     error: string | null;
-  //   };
-  //   collectInfo: {
-  //     loading: boolean;
-  //     valid: boolean;
-  //     error: string | null;
-  //   };
-  //   resend: {
-  //     loading: boolean;
-  //     error: string | null;
-  //   };
-  //   verifyCode: {
-  //     loading: boolean;
-  //     error: string | null;
-  //   };
-  // };
-  // recoveryState: {
-  //   recoveryApply: {
-  //     loading: boolean;
-  //     error: string | null;
-  //   };
-  //   recoverySubmit: {
-  //     loading: boolean;
-  //     error: string | null;
-  //   };
-  // };
 }
 
 interface AuthActions {
   clearCognitoUser: () => void;
   setCognitoUser: (cognitoUser: CognitoUser) => void;
   setToken: (token: string) => void;
-  // setUser: (user: any) => void;
-  // signIn: ({ account, password }: { account: string; password: string }) => void;
 }
 
 const initialState: AuthState = {
   cognitoUser: null,
   token: "",
-  // user: null,
-  // tempUser: null,
-  // isMobile: false,
-  // resendConfirmCodeTimestamp: null,
-  // signInState: {
-  //   loading: false,
-  //   error: void 0,
-  // },
-  // signUpState: {
-  //   collectAccount: {
-  //     loading: false,
-  //     valid: false,
-  //     error: null,
-  //   },
-  //   verifyAccount: {
-  //     loading: false,
-  //     valid: false,
-  //     error: null,
-  //   },
-  //   collectInfo: {
-  //     loading: false,
-  //     valid: false,
-  //     error: null,
-  //   },
-  //   resend: {
-  //     loading: false,
-  //     error: null,
-  //   },
-  //   verifyCode: {
-  //     loading: false,
-  //     error: null,
-  //   },
-  // },
-  // recoveryState: {
-  //   recoveryApply: {
-  //     loading: false,
-  //     error: null,
-  //   },
-  //   recoverySubmit: {
-  //     loading: false,
-  //     error: null,
-  //   },
-  // },
 };
-
-// account and password come from sign-in form; account could be email or phone number
-// function signIn({ account, password }) {
-//   const isMobile = isValidMobilePhone(account);
-//   actions.set((state) => {
-//     state.signInState.loading = true;
-//     state.signInState.error = void 0;
-//     state.isMobile = isMobile;
-//   });
-//   try {
-//     const user = await Auth.signIn(account, password);
-//     const accessToken = user.signInUserSession.accessToken.jwtToken;
-//     const idToken = user.signInUserSession.idToken.jwtToken;
-//     const { data, error } = await fetchToken({
-//       access_token: accessToken,
-//       id_token: idToken,
-//     });
-//     if (error) {
-//       throw new Error(error);
-//     }
-
-//     actions.set((state) => {
-//       state.cognitoUser = user;
-//       state.user = { ...user, ...data };
-//     });
-//   } catch (error) {
-//     actions.set(
-//       (state) =>
-//         void (state.signInState.error = String(error.message || error)),
-//     );
-//   }
-//   actions.set((state) => void (state.signInState.loading = false));
-// }),
 
 const useAuthStore = create<AuthState & AuthActions>()(
   persist(
@@ -165,13 +39,6 @@ const useAuthStore = create<AuthState & AuthActions>()(
         set((state) => {
           state.token = token;
         }),
-      // setUser: (user) =>
-      //   set((state) => {
-      //     state.user = user;
-      //   }),
-      // signIn: () => {
-      //   console.log("signIn");
-      // },
     })),
     {
       name: "auth-storage",

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { isValidPhone } from "@/utils/phone";
+
 // const typicalUser = {
 //   user_tag: "SolidScribe",
 //   first_name: "ricky",
@@ -42,29 +44,14 @@ export const UserProfileEditFormSchema = z.object({
   user_tag: z.string().min(1, { message: "User tag is required" }),
   first_name: z.string().min(1, { message: "First name is required" }),
   last_name: z.string().min(1, { message: "Last name is required" }),
-  phone1: z.string().min(1, { message: "Phone number is required" }),
+  phone1: z
+    .string()
+    .min(1, { message: "Phone number is required" })
+    .refine((val) => isValidPhone(val), {
+      message: "Please enter a valid phone number",
+    }),
   email: z.string().email({ message: "Email is required" }),
   global_user_notifications: z.boolean(),
 });
 
 export type UserProfileEditForm = z.infer<typeof UserProfileEditFormSchema>;
-
-// Pick<
-//   UserProfile,
-//   "user_tag" | "first_name" | "last_name" | "phone1" | "email"
-// >;
-
-// user can update these fields in the form
-export const UserProfileEditableSchema = z.object({
-  first_name: z.string().min(1, { message: "First name is required" }),
-  last_name: z.string().min(1, { message: "Last name is required" }),
-  phone1: z.string().min(1, { message: "Phone number is required" }),
-  global_user_notifications: z.boolean(),
-});
-
-export type UserProfileEditable = z.infer<typeof UserProfileEditableSchema>;
-
-// Pick<
-//   UserProfile,
-//   "first_name" | "last_name" | "phone1"
-// >;

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -1,9 +1,12 @@
-import parsePhoneNumber from "libphonenumber-js/mobile";
+import parsePhoneNumber, { AsYouType } from "libphonenumber-js/mobile";
 import { Platform } from "react-native";
 
 function isValidMobilePhone(value: string) {
   if (!value) return false;
-  const phoneNumber = parsePhoneNumber(value, "US");
+  const phoneNumber = parsePhoneNumber(value, {
+    defaultCountry: "US",
+    extract: false,
+  });
   if (phoneNumber?.isValid()) {
     if (phoneNumber.getType() === "MOBILE") {
       return true;
@@ -14,7 +17,10 @@ function isValidMobilePhone(value: string) {
 
 function isValidPhone(value: string) {
   if (!value) return false;
-  const phoneNumber = parsePhoneNumber(value, "US");
+  const phoneNumber = parsePhoneNumber(value, {
+    defaultCountry: "US",
+    extract: false,
+  });
   if (phoneNumber?.isValid()) {
     return true;
   }
@@ -22,9 +28,12 @@ function isValidPhone(value: string) {
 }
 
 // returns (801) 225-6115 or null
-function phoneFormatter(inputPhoneNumber: string | null) {
+function phoneFormatter(inputPhoneNumber: string) {
   if (!inputPhoneNumber) return null;
-  const phoneNumber = parsePhoneNumber(inputPhoneNumber, "US");
+  const phoneNumber = parsePhoneNumber(inputPhoneNumber, {
+    defaultCountry: "US",
+    extract: false,
+  });
   if (phoneNumber?.isValid()) {
     return phoneNumber.formatNational();
   }
@@ -34,9 +43,25 @@ function phoneFormatter(inputPhoneNumber: string | null) {
 // returns 8012256115 or null
 function phoneFormatterDigitsOnly(inputPhoneNumber: string) {
   if (!inputPhoneNumber) return null;
-  const phoneNumber = parsePhoneNumber(inputPhoneNumber, "US");
+  const phoneNumber = parsePhoneNumber(inputPhoneNumber, {
+    defaultCountry: "US",
+    extract: false,
+  });
   if (phoneNumber?.isValid()) {
     return phoneNumber.nationalNumber;
+  }
+  return null;
+}
+
+// returns +18012256115 or null
+function phoneFormatterE164(inputPhoneNumber: string) {
+  if (!inputPhoneNumber) return null;
+  const phoneNumber = parsePhoneNumber(inputPhoneNumber, {
+    defaultCountry: "US",
+    extract: false,
+  });
+  if (phoneNumber?.isValid()) {
+    return phoneNumber.number;
   }
   return null;
 }
@@ -48,8 +73,11 @@ function phoneFormatterAsLink(phoneNumber: string) {
 }
 
 export {
+  AsYouType,
   isValidMobilePhone,
   isValidPhone,
   phoneFormatter,
+  phoneFormatterDigitsOnly,
+  phoneFormatterE164,
   phoneFormatterAsLink,
 };


### PR DESCRIPTION
Improve phone parsing and formatting utils
The `extract: false` option treats non-phone-number characters differently, better

And phone handling in Profile edit
Show user one format, store another

ALSO:
Better icon `type` handling for Wallet history