### PR TITLE
Resolve dependency error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "babel-plugin-module-resolver": "5.0.2",
         "eslint": "^8.57.0",
         "eslint-config-expo": "~8.0.1",
-        "eslint-config-prettier": "10.0.2",
+        "eslint-config-prettier": "10.1.1",
         "eslint-plugin-prettier": "5.2.5",
         "husky": "9.1.7",
         "jest": "^29.2.1",
@@ -13021,13 +13021,13 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.2.tgz",
-      "integrity": "sha512-1105/17ZIMjmCOJOPNfVdbXafLCLj3hPmkmB7dLgt7XsQ/zkxSuDerE/xgO3RxoHysR1N1whmquY0lSn2O0VLg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
+      "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "eslint-config-prettier": "build/bin/cli.js"
+        "eslint-config-prettier": "bin/cli.js"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "babel-plugin-module-resolver": "5.0.2",
     "eslint": "^8.57.0",
     "eslint-config-expo": "~8.0.1",
-    "eslint-config-prettier": "10.0.2",
+    "eslint-config-prettier": "10.1.1",
     "eslint-plugin-prettier": "5.2.5",
     "husky": "9.1.7",
     "jest": "^29.2.1",


### PR DESCRIPTION
eslint-config-prettier@10.1.1

Running "npm install" in /home/expo/workingdir/build/ directory npm ERR! code ERESOLVE
npm ERR! ERESOLVE
could not resolve
npm ERR!
npm
ERR! While resolving: eslint-plugin-prettier@5.2.5 npm ERR! Found: eslint-config-prettier@10.0.2
npm ERR! node_modules/eslint-config-prettier
npm ERR!   dev eslint-config-prettier@"10.0.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR!
peerOptional eslint-config-prettier@">= 7.0.0 <10.0.0 || >=10.1.0" from eslint-plugin-prettier@5.2.5
npm ERR! node_modules/eslint-plugin-prettier
npm ERR!
dev eslint-plugin-prettier@"5.2.5" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: eslint-config-prettier@10.1.1
npm ERR! node_modules/eslint-config-prettier
npm ERR!   peerOptional eslint-config-prettier@">= 7.0.0 <10.0.0 || >=10.1.0" from eslint-plugin-prettier@5.2.5
npm ERR!   node_modules/eslint-plugin-prettier
npm ERR!     dev eslint-plugin-prettier@"5.2.5" from the root project
npm
ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR!
npm ERR! For a full report see:
npm ERR! /home/expo/.npm/_logs/2025-03-28T07_41_25_496Z-eresolve-report.txt
npm ERR! A complete log of this run can be found in: /home/expo/.npm/_logs/2025-03-28T07_41_25_496Z-debug-0.log
npm install exited with non-zero code: 1